### PR TITLE
Fixing some Countries Paypal base fee rate

### DIFF
--- a/discogsFeesCalculator.js
+++ b/discogsFeesCalculator.js
@@ -22,6 +22,11 @@ const paypalBaseFees = [
 	    "Guadeloupe",
 	    "Martinique",
 	    "Reunion",
+	  ],
+	  baseFee: 0.029,
+        },
+	{
+	  country: [
 	    "Austria",
 	    "Belgium",
 	    "Denmark",
@@ -468,7 +473,7 @@ const paypalBaseFees = [
 	  case "Guernsey ":
 	  case "Jersey ":
 	  case "United Kingdom":
-	  // https://www.paypal.com/es/webapps/mpp/merchant-fees
+	  // https://www.paypal.com/uk/webapps/mpp/merchant-fees
       
 	  // All countries below have the same Paypal fees.
 	  // See: https://www.paypal.com/bg/webapps/mpp/merchant-fees


### PR DESCRIPTION
Fixing the following Coutries Paypal base fee rate:"
- Canada
- Poland
- Portugal
- Spain
- Isle Of Man
- Guernsey
- Jersey
- United Kingdom
- France
- French Guiana
- Guadeloupe
- Martinique
- Reunion